### PR TITLE
Add registration requirement notice to CfP pages

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -1014,6 +1014,12 @@
   },
   "call_for_papers": {
     "title": "Call for Papers",
+    "registration_notice": {
+      "title": "Conference Registration Required",
+      "body_prefix": "All conference participants, including speakers and presenters, are required to register for the conference. Please complete your registration through the ",
+      "body_link": "registration page",
+      "body_suffix": "."
+    },
     "general_sessions": {
       "title": "General Sessions",
       "description": "Information about general presentation submissions.",

--- a/src/lib/translations/ja.json
+++ b/src/lib/translations/ja.json
@@ -861,6 +861,12 @@
   },
   "call_for_papers": {
     "title": "発表募集",
+    "registration_notice": {
+      "title": "カンファレンス参加登録について",
+      "body_prefix": "登壇者・発表者を含む全てのカンファレンス参加者は、参加登録が必要です。",
+      "body_link": "登録ページ",
+      "body_suffix": "より参加登録をお済ませください。"
+    },
     "general_sessions": {
       "title": "一般セッション",
       "description": "一般発表の投稿に関する情報。",

--- a/src/routes/[lang=lang]/call-for-papers/academic-track/+page.svelte
+++ b/src/routes/[lang=lang]/call-for-papers/academic-track/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { t } from 'svelte-i18n'
+  import { page } from '$app/stores'
   import Table from '$components/Table.svelte'
   import SubmitButton from '$components/SubmitButton.svelte'
+
+  $: lang = $page.params.lang
 </script>
 
 <svelte:head>
@@ -19,6 +22,8 @@
   />
   
   <div class="prose max-w-none">
+    <h2 class="text-2xl font-semibold mb-4">{$t('call_for_papers.registration_notice.title')}</h2>
+    <p class="mb-6">{$t('call_for_papers.registration_notice.body_prefix')}<a href="/{lang}/register/registration" class="text-blue-600 hover:text-blue-800 hover:underline">{$t('call_for_papers.registration_notice.body_link')}</a>{$t('call_for_papers.registration_notice.body_suffix')}</p>
     <!-- Overview -->
     <h2 class="text-2xl font-semibold mb-4">{$t('call_for_papers.academic_track.overview.title')}</h2>
     <p class="mb-6">

--- a/src/routes/[lang=lang]/call-for-papers/general-sessions/+page.svelte
+++ b/src/routes/[lang=lang]/call-for-papers/general-sessions/+page.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
   import { t } from 'svelte-i18n'
+  import { page } from '$app/stores'
   import ComingSoon from '$components/ComingSoon.svelte'
   import Table from '$components/Table.svelte'
   import SubmitButton from '$components/SubmitButton.svelte'
+
+  $: lang = $page.params.lang
 </script>
 
 <svelte:head>
@@ -20,11 +23,13 @@
   />
   
   <div class="prose max-w-none">
+    <h2 class="text-2xl font-semibold mb-4">{$t('call_for_papers.registration_notice.title')}</h2>
+    <p class="mb-6">{$t('call_for_papers.registration_notice.body_prefix')}<a href="/{lang}/register/registration" class="text-blue-600 hover:text-blue-800 hover:underline">{$t('call_for_papers.registration_notice.body_link')}</a>{$t('call_for_papers.registration_notice.body_suffix')}</p>
     <h2 class="text-2xl font-semibold mb-4">{$t('call_for_papers.general_sessions.topics.title')}</h2>
     <p class="mb-6">
       {$t('call_for_papers.general_sessions.topics.intro')}
     </p>
-    
+
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
       <div>
         <h3 class="text-lg font-semibold mb-2">{$t('call_for_papers.general_sessions.topics.technical_topics.title')}</h3>

--- a/src/routes/[lang=lang]/call-for-papers/workshops/+page.svelte
+++ b/src/routes/[lang=lang]/call-for-papers/workshops/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { t } from 'svelte-i18n'
+  import { page } from '$app/stores'
   import Table from '$components/Table.svelte'
   import SubmitButton from '$components/SubmitButton.svelte'
+
+  $: lang = $page.params.lang
 </script>
 
 <svelte:head>
@@ -19,6 +22,8 @@
   />
   
   <div class="prose max-w-none">
+    <h2 class="text-2xl font-semibold mb-4">{$t('call_for_papers.registration_notice.title')}</h2>
+    <p class="mb-6">{$t('call_for_papers.registration_notice.body_prefix')}<a href="/{lang}/register/registration" class="text-blue-600 hover:text-blue-800 hover:underline">{$t('call_for_papers.registration_notice.body_link')}</a>{$t('call_for_papers.registration_notice.body_suffix')}</p>
     <!-- Overview -->
     <h2 class="text-2xl font-semibold mb-4">{$t('call_for_papers.workshops.overview.title')}</h2>
     <p class="mb-6">


### PR DESCRIPTION
Summary
CfP（発表募集）の全ページ（General Sessions、Academic Track、Workshops）に、カンファレンス参加登録が必要である旨の案内を追加
登録ページへのリンク付きの注意書きを各ページ冒頭に表示
日英両言語の翻訳ファイル（en.json / ja.json）に registration_notice キーを追加
Changes
src/lib/translations/en.json / ja.json: 参加登録必須の案内文を翻訳キーとして追加
call-for-papers/general-sessions/+page.svelte
call-for-papers/academic-track/+page.svelte
call-for-papers/workshops/+page.svelte: 各ページに登録案内セクション（見出し＋リンク付き本文）を追加。$page.params.lang を使って言語対応のリンクを生成