### PR TITLE
Add accommodation section with hotel listings and map integration

### DIFF
--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -26,6 +26,11 @@
         <div class="text-center loading-none">
           {#if item.icon}
             <img src={item.icon} alt={item.title} class="w-6 h-6" />
+          {:else if item.label !== undefined}
+            <!-- Numbered circle marker -->
+            <div class="flex items-center justify-center w-8 h-8 rounded-full bg-red-500 text-white text-xs font-bold shadow-md border-2 border-white leading-none">
+              {item.label}
+            </div>
           {:else}
             <!-- Standard map pin marker -->
             <svg width="40" height="40" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" class={item.color || "text-red-500"}>

--- a/src/lib/config/navigation.ts
+++ b/src/lib/config/navigation.ts
@@ -51,7 +51,7 @@ export const navigationConfig = {
       venue: { enabled: true },
       transport: { enabled: true },
       travelGuide: { enabled: false }, // Disabled per user request
-      accommodation: { enabled: false }, // Disabled per user request
+      accommodation: { enabled: true },
       childcare: { enabled: false }
     }
   },

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -531,34 +531,63 @@
   },
   "accommodation": {
     "title": "Accommodation",
-    "recommended_hotels": {
-      "title": "Recommended Hotels",
-      "description": "We have negotiated special rates with several hotels near the conference venue. Booking information will be available with your registration confirmation."
+    "intro": "We introduce hotels, pensions, and other accommodation options in Hiroshima City.",
+    "disclaimer": "Please note that the organizing committee does not handle hotel reservations on behalf of attendees. Please book directly with each accommodation.",
+    "table": {
+      "number": "No.",
+      "name": "Name",
+      "category": "Category",
+      "website": "Website"
     },
-    "hotel_types": {
-      "luxury": {
-        "title": "Luxury Hotels",
-        "price": "¥15,000-25,000 per night",
-        "features": [
-          "Full-service amenities",
-          "English-speaking staff",
-          "Conference shuttle service"
-        ]
-      },
-      "business": {
-        "title": "Business Hotels",
-        "price": "¥8,000-15,000 per night",
-        "features": [
-          "Compact, efficient rooms",
-          "Central locations",
-          "Good value for money"
-        ]
-      }
+    "categories": {
+      "hotel": "Hotel",
+      "pension": "Guesthouse / Pension",
+      "ryokan": "Ryokan (Japanese Inn)"
     },
-    "booking_info": {
-      "title": "Booking Information",
-      "description": "Hotel booking details and special conference rates will be sent to registered attendees in Spring 2026."
-    }
+    "legend": {
+      "hotels": "Hotels",
+      "hiroshima_station": "Hiroshima Station"
+    },
+    "hotels": [
+      { "name": "ANA Crowne Plaza Hiroshima", "category": "hotel", "url": "https://www.ihg.com/crowneplaza/hotels/us/en/hiroshima/hijja/hoteldetail", "lng": 132.4569381, "lat": 34.390445 },
+      { "name": "Mitsui Garden Hotel Hiroshima", "category": "hotel", "url": "https://www.gardenhotels.co.jp/hiroshima/eng/", "lng": 132.4592915, "lat": 34.389546 },
+      { "name": "RIHGA Royal Hotel Hiroshima", "category": "hotel", "url": "https://www.rihga.com/hiroshima", "lng": 132.4573815, "lat": 34.397438 },
+      { "name": "Hilton Hiroshima", "category": "hotel", "url": "https://www.hilton.com/en/hotels/hijshhi-hilton-hiroshima/", "lng": 132.4621165, "lat": 34.386168 },
+      { "name": "Hiroshima City Bunka Koryu Kaikan", "category": "hotel", "url": "https://h-bkk.jp/stay/", "lng": 132.4489769, "lat": 34.3887901 },
+      { "name": "Urbain Hiroshima Central", "category": "hotel", "url": "https://www.urbain-hotels.com/hce", "lng": 132.4646004, "lat": 34.39646383 },
+      { "name": "Alley Hotel Hiroshima Namiki-dori", "category": "hotel", "url": "https://www.2482255.com/", "lng": 132.4609212, "lat": 34.39073819 },
+      { "name": "WeBase HIROSHIMA", "category": "pension", "url": "https://we-base.jp/hiroshima/", "lng": 132.4592418, "lat": 34.39014592 },
+      { "name": "EN HOTEL Hiroshima", "category": "hotel", "url": "https://en-hotel.com/hiroshima/ja/", "lng": 132.4684719, "lat": 34.3915992 },
+      { "name": "Oriental Hotel Hiroshima", "category": "hotel", "url": "https://www.oriental-hiroshima.com/index.html", "lng": 132.4638647, "lat": 34.38823629 },
+      { "name": "Grand Prince Hotel Hiroshima", "category": "hotel", "url": "http://www.princehotels.co.jp/hiroshima/", "lng": 132.4640634, "lat": 34.3430145 },
+      { "name": "Koko Hotel Hiroshima Ekimae", "category": "hotel", "url": "https://koko-hotels.com/hiroshima_ekimae/", "lng": 132.472577, "lat": 34.39407666 },
+      { "name": "Sotetsu Fresa Inn Hiroshima", "category": "hotel", "url": "https://sotetsu-hotels.com/fresa-inn/hiroshima-ekimae/", "lng": 132.4766571, "lat": 34.3948531 },
+      { "name": "Toyoko Inn Hiroshima-eki Minami-guchi Migi", "category": "hotel", "url": "https://www.toyoko-inn.com/search/detail/00145/", "lng": 132.4682221, "lat": 34.39673776 },
+      { "name": "Hiroshima Intelligent Hotel Annex", "category": "hotel", "url": "http://www.intelligent-hotel.co.jp/annex/", "lng": 132.4703289, "lat": 34.39241577 },
+      { "name": "Hiroshima Intelligent Hotel Stadium", "category": "hotel", "url": "https://intelligent-hotel.co.jp/main/", "lng": 132.4797677, "lat": 34.39462614 },
+      { "name": "Hiroshima Guesthouse EN", "category": "pension", "url": "https://hostel-en.com/", "lng": 132.4507593, "lat": 34.4079974 },
+      { "name": "Hiroshima Guesthouse HARU", "category": "pension", "url": "", "lng": 132.4817685, "lat": 34.3904329 },
+      { "name": "Hiroshima Tokyu Rei Hotel", "category": "hotel", "url": "https://www.tokyuhotels.co.jp/hiroshima-r/index.html", "lng": 132.4616894, "lat": 34.38883199 },
+      { "name": "Hiroshima no Yado Aioi", "category": "ryokan", "url": "https://aioi-hiroshima.com/", "lng": 132.4544134, "lat": 34.3954727 },
+      { "name": "Hiroshima Pacific Hotel", "category": "hotel", "url": "http://h-pacific.com/", "lng": 132.4643062, "lat": 34.3982047 },
+      { "name": "Hiroshima Peace Hotel", "category": "hotel", "url": "http://www.peace-h.com/", "lng": 132.4495825, "lat": 34.4088008 },
+      { "name": "Vessel Inn Hiroshima Ekimae", "category": "hotel", "url": "https://www.vessel-hotel.jp/inn/hiroshima/", "lng": 132.4782534, "lat": 34.39334891 },
+      { "name": "Hostel Mallika", "category": "pension", "url": "", "lng": 132.4500149, "lat": 34.3898512 },
+      { "name": "Hotel Granvia Hiroshima", "category": "hotel", "url": "http://hgh.co.jp/", "lng": 132.4755149, "lat": 34.39912045 },
+      { "name": "Hotel Kuretakeso Hiroshima Otemachi", "category": "hotel", "url": "http://www.kuretake-inn.com/hiroshima/", "lng": 132.454945, "lat": 34.38812005 },
+      { "name": "Hotel New Yorishiro", "category": "hotel", "url": "https://yorishiro.info/", "lng": 132.4801717, "lat": 34.39690965 },
+      { "name": "Hiroshima Garden Palace", "category": "hotel", "url": "https://www.hotelgp-hiroshima.com/", "lng": 132.4801576, "lat": 34.3969038 },
+      { "name": "Hotel Promote Hiroshima", "category": "hotel", "url": "https://www.promote-hiroshima.com/", "lng": 132.4445982, "lat": 34.3936264 },
+      { "name": "Hotel Hokke Club Hiroshima", "category": "hotel", "url": "https://www.hokke.co.jp/hiroshima/", "lng": 132.4575986, "lat": 34.39042452 },
+      { "name": "Hotel Mystays Hiroshima Peace Park", "category": "hotel", "url": "https://www.mystays.com/hotel-mystays-hiroshima-peace-park-hiroshima/", "lng": 132.4540476, "lat": 34.38964371 },
+      { "name": "LAZULI HIROSHIMA HOTEL&LOUNGE", "category": "ryokan", "url": "https://lazulihiroshima.com/", "lng": 132.4794683, "lat": 34.39080284 },
+      { "name": "Urbain Hiroshima Executive", "category": "hotel", "url": "https://www.urbain-hotels.com/hex/", "lng": 132.4800296, "lat": 34.3970976 },
+      { "name": "Hotel Park Side Hiroshima Peace Park", "category": "hotel", "url": "https://www.park-side.co.jp/", "lng": 132.4555812, "lat": 34.3922827 },
+      { "name": "HOTEL GRANVIA HIROSHIMA SOUTH GATE", "category": "hotel", "url": "https://southgate.hgh.co.jp/", "lng": 132.4752182, "lat": 34.39740833 },
+      { "name": "HOTEL SUITE HIROSHIMA YOKOGAWA", "category": "hotel", "url": "https://www.hotelsuite.co.jp/yokogawa/", "lng": 132.4520592, "lat": 34.41279636 },
+      { "name": "HOTEL SUITE HIROSHIMA HAKUSHIMA", "category": "hotel", "url": "https://www.hotelsuite.co.jp/hakushima/", "lng": 132.4659868, "lat": 34.40562895 },
+      { "name": "J-Hoppers Hiroshima Guesthouse", "category": "pension", "url": "https://hiroshima.j-hoppers.com/ja/", "lng": 132.4472315, "lat": 34.3930168 }
+    ]
   },
   "childcare": {
     "title": "Childcare",

--- a/src/lib/translations/ja.json
+++ b/src/lib/translations/ja.json
@@ -408,6 +408,66 @@
       "description": "託児サービスの提供に関する情報。"
     }
   },
+  "accommodation": {
+    "title": "宿泊",
+    "intro": "広島市内のホテルやペンションをご紹介します。",
+    "disclaimer": "運営メンバーからホテルの予約を代行することはありません。各施設へ直接ご予約ください。",
+    "table": {
+      "number": "No.",
+      "name": "名称",
+      "category": "カテゴリ",
+      "website": "Webサイト"
+    },
+    "categories": {
+      "hotel": "ホテル",
+      "pension": "ペンション・コテージ",
+      "ryokan": "旅館"
+    },
+    "legend": {
+      "hotels": "ホテル等",
+      "hiroshima_station": "広島駅"
+    },
+    "hotels": [
+      { "name": "ANA Crowne Plaza Hiroshima", "category": "hotel", "url": "https://www.ihg.com/crowneplaza/hotels/us/en/hiroshima/hijja/hoteldetail", "lng": 132.4569381, "lat": 34.390445 },
+      { "name": "Mitsui Garden Hotel Hiroshima", "category": "hotel", "url": "https://www.gardenhotels.co.jp/hiroshima/eng/", "lng": 132.4592915, "lat": 34.389546 },
+      { "name": "RIHGA Royal Hotel Hiroshima", "category": "hotel", "url": "https://www.rihga.com/hiroshima", "lng": 132.4573815, "lat": 34.397438 },
+      { "name": "Hilton Hiroshima", "category": "hotel", "url": "https://www.hilton.com/en/hotels/hijshhi-hilton-hiroshima/", "lng": 132.4621165, "lat": 34.386168 },
+      { "name": "Hiroshima City Bunka Koryu Kaikan", "category": "hotel", "url": "https://h-bkk.jp/stay/", "lng": 132.4489769, "lat": 34.3887901 },
+      { "name": "Urbain Hiroshima Central", "category": "hotel", "url": "https://www.urbain-hotels.com/hce", "lng": 132.4646004, "lat": 34.39646383 },
+      { "name": "Alley Hotel Hiroshima Namiki-dori", "category": "hotel", "url": "https://www.2482255.com/", "lng": 132.4609212, "lat": 34.39073819 },
+      { "name": "WeBase HIROSHIMA", "category": "pension", "url": "https://we-base.jp/hiroshima/", "lng": 132.4592418, "lat": 34.39014592 },
+      { "name": "EN HOTEL Hiroshima", "category": "hotel", "url": "https://en-hotel.com/hiroshima/ja/", "lng": 132.4684719, "lat": 34.3915992 },
+      { "name": "Oriental Hotel Hiroshima", "category": "hotel", "url": "https://www.oriental-hiroshima.com/index.html", "lng": 132.4638647, "lat": 34.38823629 },
+      { "name": "Grand Prince Hotel Hiroshima", "category": "hotel", "url": "http://www.princehotels.co.jp/hiroshima/", "lng": 132.4640634, "lat": 34.3430145 },
+      { "name": "Koko Hotel Hiroshima Ekimae", "category": "hotel", "url": "https://koko-hotels.com/hiroshima_ekimae/", "lng": 132.472577, "lat": 34.39407666 },
+      { "name": "Sotetsu Fresa Inn Hiroshima", "category": "hotel", "url": "https://sotetsu-hotels.com/fresa-inn/hiroshima-ekimae/", "lng": 132.4766571, "lat": 34.3948531 },
+      { "name": "Toyoko Inn Hiroshima-eki Minami-guchi Migi", "category": "hotel", "url": "https://www.toyoko-inn.com/search/detail/00145/", "lng": 132.4682221, "lat": 34.39673776 },
+      { "name": "Hiroshima Intelligent Hotel Annex", "category": "hotel", "url": "http://www.intelligent-hotel.co.jp/annex/", "lng": 132.4703289, "lat": 34.39241577 },
+      { "name": "Hiroshima Intelligent Hotel Stadium", "category": "hotel", "url": "https://intelligent-hotel.co.jp/main/", "lng": 132.4797677, "lat": 34.39462614 },
+      { "name": "Hiroshima Guesthouse EN", "category": "pension", "url": "https://hostel-en.com/", "lng": 132.4507593, "lat": 34.4079974 },
+      { "name": "Hiroshima Guesthouse HARU", "category": "pension", "url": "", "lng": 132.4817685, "lat": 34.3904329 },
+      { "name": "Hiroshima Tokyu Rei Hotel", "category": "hotel", "url": "https://www.tokyuhotels.co.jp/hiroshima-r/index.html", "lng": 132.4616894, "lat": 34.38883199 },
+      { "name": "Hiroshima no Yado Aioi", "category": "ryokan", "url": "https://aioi-hiroshima.com/", "lng": 132.4544134, "lat": 34.3954727 },
+      { "name": "Hiroshima Pacific Hotel", "category": "hotel", "url": "http://h-pacific.com/", "lng": 132.4643062, "lat": 34.3982047 },
+      { "name": "Hiroshima Peace Hotel", "category": "hotel", "url": "http://www.peace-h.com/", "lng": 132.4495825, "lat": 34.4088008 },
+      { "name": "Vessel Inn Hiroshima Ekimae", "category": "hotel", "url": "https://www.vessel-hotel.jp/inn/hiroshima/", "lng": 132.4782534, "lat": 34.39334891 },
+      { "name": "Hostel Mallika", "category": "pension", "url": "", "lng": 132.4500149, "lat": 34.3898512 },
+      { "name": "Hotel Granvia Hiroshima", "category": "hotel", "url": "http://hgh.co.jp/", "lng": 132.4755149, "lat": 34.39912045 },
+      { "name": "Hotel Kuretakeso Hiroshima Otemachi", "category": "hotel", "url": "http://www.kuretake-inn.com/hiroshima/", "lng": 132.454945, "lat": 34.38812005 },
+      { "name": "Hotel New Yorishiro", "category": "hotel", "url": "https://yorishiro.info/", "lng": 132.4801717, "lat": 34.39690965 },
+      { "name": "Hiroshima Garden Palace", "category": "hotel", "url": "https://www.hotelgp-hiroshima.com/", "lng": 132.4801576, "lat": 34.3969038 },
+      { "name": "Hotel Promote Hiroshima", "category": "hotel", "url": "https://www.promote-hiroshima.com/", "lng": 132.4445982, "lat": 34.3936264 },
+      { "name": "Hotel Hokke Club Hiroshima", "category": "hotel", "url": "https://www.hokke.co.jp/hiroshima/", "lng": 132.4575986, "lat": 34.39042452 },
+      { "name": "Hotel Mystays Hiroshima Peace Park", "category": "hotel", "url": "https://www.mystays.com/hotel-mystays-hiroshima-peace-park-hiroshima/", "lng": 132.4540476, "lat": 34.38964371 },
+      { "name": "LAZULI HIROSHIMA HOTEL&LOUNGE", "category": "ryokan", "url": "https://lazulihiroshima.com/", "lng": 132.4794683, "lat": 34.39080284 },
+      { "name": "Urbain Hiroshima Executive", "category": "hotel", "url": "https://www.urbain-hotels.com/hex/", "lng": 132.4800296, "lat": 34.3970976 },
+      { "name": "Hotel Park Side Hiroshima Peace Park", "category": "hotel", "url": "https://www.park-side.co.jp/", "lng": 132.4555812, "lat": 34.3922827 },
+      { "name": "HOTEL GRANVIA HIROSHIMA SOUTH GATE", "category": "hotel", "url": "https://southgate.hgh.co.jp/", "lng": 132.4752182, "lat": 34.39740833 },
+      { "name": "HOTEL SUITE HIROSHIMA YOKOGAWA", "category": "hotel", "url": "https://www.hotelsuite.co.jp/yokogawa/", "lng": 132.4520592, "lat": 34.41279636 },
+      { "name": "HOTEL SUITE HIROSHIMA HAKUSHIMA", "category": "hotel", "url": "https://www.hotelsuite.co.jp/hakushima/", "lng": 132.4659868, "lat": 34.40562895 },
+      { "name": "J-Hoppers Hiroshima Guesthouse", "category": "pension", "url": "https://hiroshima.j-hoppers.com/ja/", "lng": 132.4472315, "lat": 34.3930168 }
+    ]
+  },
   "childcare": {
       "title": "託児サービス",
       "description": "FOSS4G Hiroshima 2026では、小さなご家族がいる人も参加しやすいように、託児サービスを提供します。"

--- a/src/routes/[lang=lang]/attending/accommodation/+page.svelte
+++ b/src/routes/[lang=lang]/attending/accommodation/+page.svelte
@@ -1,5 +1,17 @@
 <script lang="ts">
   import { t } from 'svelte-i18n'
+  import Map from '$components/Map.svelte'
+
+  type Hotel = { name: string; category: string; url: string; lng: number; lat: number }
+
+  $: hotels = $t('accommodation.hotels') as unknown as Hotel[]
+
+  $: mapItems = hotels.map((hotel, i) => ({
+    coordinates: [hotel.lng, hotel.lat] as [number, number],
+    label: i + 1,
+    title: hotel.name,
+    description: hotel.name,
+  }))
 </script>
 
 <svelte:head>
@@ -7,9 +19,79 @@
 </svelte:head>
 
 <div class="container mx-auto px-4 py-8">
-  <h1 class="text-4xl font-bold mb-8">{$t('nav.attending_sub.accommodation')}</h1>
-  
-  <div class="prose max-w-none">
-    <p class="text-lg text-center">Coming soon</p>
+  <h1 class="text-4xl font-bold mb-8">{$t('accommodation.title')}</h1>
+
+  <p class="mb-4 text-lg">{$t('accommodation.intro')}</p>
+
+  <div class="bg-yellow-50 border border-yellow-300 rounded-lg p-4 mb-8">
+    <p class="text-gray-700">{$t('accommodation.disclaimer')}</p>
+  </div>
+
+  <!-- Map -->
+  <div class="mb-8">
+    <Map
+      mapClass="w-full h-96 rounded-lg"
+      center={[132.462, 34.394]}
+      zoom={12}
+      style={$t('map.settings.style')}
+      items={[
+        ...mapItems,
+        { coordinates: [132.451043, 34.392077] as [number, number], title: $t('venue.main_venue.title'), description: $t('venue.main_venue.title'), color: 'text-blue-600' },
+        { coordinates: [132.46937446033377, 34.395002597128396] as [number, number], title: $t('venue.workshop_venue.title'), description: $t('venue.workshop_venue.title'), color: 'text-green-600' },
+        { coordinates: [132.4754913298887, 34.397656485682845] as [number, number], title: $t('accommodation.legend.hiroshima_station'), description: $t('accommodation.legend.hiroshima_station'), color: 'text-orange-500' },
+      ]}
+    />
+  </div>
+
+  <!-- Map Legend -->
+  <div class="flex flex-wrap gap-4 mb-8 text-sm">
+    <div class="flex items-center gap-2">
+      <div class="w-4 h-4 rounded-full bg-red-500"></div>
+      <span>{$t('accommodation.legend.hotels')}</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="text-blue-600"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" fill="currentColor"/></svg>
+      <span>{$t('venue.main_venue.title')}</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="text-green-600"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" fill="currentColor"/></svg>
+      <span>{$t('venue.workshop_venue.title')}</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" class="text-orange-500"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" fill="currentColor"/></svg>
+      <span>{$t('accommodation.legend.hiroshima_station')}</span>
+    </div>
+  </div>
+
+  <!-- Hotel Table -->
+  <div class="overflow-x-auto">
+    <table class="w-full border-collapse text-sm">
+      <thead>
+        <tr class="bg-gray-100">
+          <th class="border border-gray-300 px-3 py-2 text-left w-12">{$t('accommodation.table.number')}</th>
+          <th class="border border-gray-300 px-3 py-2 text-left">{$t('accommodation.table.name')}</th>
+          <th class="border border-gray-300 px-3 py-2 text-left w-36">{$t('accommodation.table.category')}</th>
+          <th class="border border-gray-300 px-3 py-2 text-left w-28">{$t('accommodation.table.website')}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each hotels as hotel, i}
+          <tr class="hover:bg-gray-50">
+            <td class="border border-gray-300 px-3 py-2 text-center">{i + 1}</td>
+            <td class="border border-gray-300 px-3 py-2">{hotel.name}</td>
+            <td class="border border-gray-300 px-3 py-2">{$t(`accommodation.categories.${hotel.category}`)}</td>
+            <td class="border border-gray-300 px-3 py-2 text-center">
+              {#if hotel.url}
+                <a href={hotel.url} target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
+                  {$t('accommodation.table.website')}
+                </a>
+              {:else}
+                -
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
   </div>
 </div>


### PR DESCRIPTION
This pull request adds a comprehensive accommodation section for the event, including a map and a detailed table of hotels, pensions, and ryokan in Hiroshima City. It enables the accommodation page in the navigation, introduces new translations and data for both English and Japanese, and enhances the map component to support numbered markers for hotels.

**Accommodation Section Implementation:**

- Adds a new accommodation page at `src/routes/[lang=lang]/attending/accommodation/+page.svelte` that displays:
  - An interactive map with numbered markers for each hotel, as well as markers for the main venue, workshop venue, and Hiroshima Station.
  - A legend explaining map markers.
  - A table listing all accommodation options with names, categories, and website links. ([src/routes/[lang=lang]/attending/accommodation/+page.svelteR3-R95](diffhunk://#diff-21f75786585acebc354cbc322dc4ee81e3c77dd30cb38bc3113d1e4cef8d16c2R3-R95))

- Enables the accommodation link in the navigation by setting `accommodation: { enabled: true }` in `src/lib/config/navigation.ts`.

**Translations and Data:**

- Overhauls the accommodation section in both English (`src/lib/translations/en.json`) and Japanese (`src/lib/translations/ja.json`) translations:
  - Replaces previous hotel info with a new structure: introduction, disclaimer, table headers, categories, legend, and a detailed list of hotels with coordinates and URLs. [[1]](diffhunk://#diff-cf6e999e144d694c1e0b044e8b347d67c63c40327af61f564abff9aeb5dd3f61L534-L561) [[2]](diffhunk://#diff-abe84f31155db319eb7acd438bf44b2a3a11d3226414a6d0f6defbe74a83487bR411-R470)

**Map Component Enhancement:**

- Updates `src/components/Map.svelte` to render a numbered circle marker when an item has a `label` property, improving the visual distinction of hotel markers on the map.