### PR TITLE
Fix sponsor category titles

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -96,8 +96,8 @@
     },
     "sponsors": {
       "title": "Sponsors",
-      "media_sponsor": "Media Sponsor",
-      "supporting_sponsors": "Supporting Sponsors"
+      "media_partners": "Media Partners",
+      "supporter_sponsor": "Supporter Sponsors"
     }
   },
   "nav": {

--- a/src/lib/translations/ja.json
+++ b/src/lib/translations/ja.json
@@ -183,8 +183,8 @@
     },
     "sponsors": {
       "title": "スポンサー",
-      "media_sponsor": "メディアスポンサー",
-      "supporting_sponsors": "サポーティングスポンサー"
+      "media_partners": "メディアパートナー",
+      "supporter_sponsor": "サポータースポンサー"
     }
   },
   "common": {

--- a/src/routes/[lang=lang]/+page.svelte
+++ b/src/routes/[lang=lang]/+page.svelte
@@ -126,9 +126,9 @@
       <h2 class="text-2xl sm:text-3xl font-bold text-slate-800">{$t('teaser.sponsors.title')}</h2>
     </div>
     
-    <!-- Media Sponsor -->
+    <!-- Media Partners -->
     <div class="mb-8">
-      <h3 class="text-xl font-semibold text-slate-700 mb-4 text-center">{$t('teaser.sponsors.media_sponsor')}</h3>
+      <h3 class="text-xl font-semibold text-slate-700 mb-4 text-center">{$t('teaser.sponsors.media_partners')}</h3>
       <div class="flex items-center justify-center">
         <a href="https://www.gisnext.jp/" target="_blank" rel="noopener noreferrer" class="block">
           <img 
@@ -140,9 +140,9 @@
       </div>
     </div>
     
-    <!-- Supporting Sponsors -->
+    <!-- Supporter Sponsors -->
     <div>
-      <h3 class="text-xl font-semibold text-slate-700 mb-4 text-center">{$t('teaser.sponsors.supporting_sponsors')}</h3>
+      <h3 class="text-xl font-semibold text-slate-700 mb-4 text-center">{$t('teaser.sponsors.supporter_sponsor')}</h3>
       <div class="flex items-center justify-center">
         <a href="https://ti.to/" target="_blank" rel="noopener noreferrer" class="block">
           <img 

--- a/src/routes/[lang=lang]/sponsors/+page.svelte
+++ b/src/routes/[lang=lang]/sponsors/+page.svelte
@@ -151,9 +151,9 @@
   <div class="mt-12">
     <h2 class="text-2xl font-semibold mb-8 text-center">{$t('about.sponsors.current_sponsors.title')}</h2>
     
-    <!-- Media Sponsor -->
+    <!-- Media Partners -->
     <div class="mb-10">
-      <h3 class="text-xl font-semibold text-slate-700 mb-6 text-center">{$t('teaser.sponsors.media_sponsor')}</h3>
+      <h3 class="text-xl font-semibold text-slate-700 mb-6 text-center">{$t('teaser.sponsors.media_partners')}</h3>
       <div class="flex items-center justify-center bg-white p-8 rounded-lg shadow-md">
         <a href="https://www.gisnext.jp/" target="_blank" rel="noopener noreferrer" class="block">
           <img 
@@ -165,9 +165,9 @@
       </div>
     </div>
     
-    <!-- Supporting Sponsors -->
+    <!-- Supporter Sponsors -->
     <div>
-      <h3 class="text-xl font-semibold text-slate-700 mb-6 text-center">{$t('teaser.sponsors.supporting_sponsors')}</h3>
+      <h3 class="text-xl font-semibold text-slate-700 mb-6 text-center">{$t('teaser.sponsors.supporter_sponsor')}</h3>
       <div class="flex items-center justify-center bg-white p-8 rounded-lg shadow-md">
         <a href="https://ti.to/" target="_blank" rel="noopener noreferrer" class="block">
           <img 


### PR DESCRIPTION
## Summary
- Rename "Media Sponsor" to "Media Partners" (GIS Next)
- Rename "Supporting Sponsors" to "Supporter Sponsors" (Tito)
- Update i18n keys, translation values (en/ja), and HTML comments

## Test plan
- [x] Verify homepage sponsor section shows "Media Partners" and "Supporter Sponsors"
- [x] Verify sponsors page shows the same corrected titles
- [x] Confirm both English and Japanese translations display correctly

Closes #38