### PR TITLE
Switch map tile provider to Protomaps

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -183,7 +183,7 @@
   },
   "map": {
     "settings": {
-      "style": "https://tile.openstreetmap.jp/styles/maptiler-basic-en/style.json"
+      "style": "https://api.protomaps.com/styles/v5/light/en.json?key=8c20b570634902e7"
     },
     "title": {
       "main_venue": "Main Venue"

--- a/src/lib/translations/ja.json
+++ b/src/lib/translations/ja.json
@@ -78,7 +78,7 @@
   },
   "map": {
     "settings": {
-      "style": "https://tile.openstreetmap.jp/styles/maptiler-basic-ja/style.json"
+      "style": "https://api.protomaps.com/styles/v5/light/en.json?key=8c20b570634902e7"
     },
     "title": {
       "main_venue": "メイン会場"


### PR DESCRIPTION
## Summary
- Replace tile.openstreetmap.jp with Protomaps API for all map instances
- Affects homepage, about/map, venue, and accommodation pages
- Both en/ja use Protomaps light/en style

## Test plan
- [ ] Map renders correctly on homepage
- [ ] Map renders correctly on About > Map page
- [ ] Map renders correctly on Attending > Venue page
- [ ] Map renders correctly on Attending > Accommodation page
- [ ] Markers and popups work as expected

Closes #52