### PR TITLE
Update all GitHub Actions to latest versions to drop node20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,15 +18,15 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'
       - name: Restore npm cache
         id: restore-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: js-depend-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
@@ -36,11 +36,11 @@ jobs:
       - name: Build
         run: npm run build
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - run: touch build/.nojekyll
       - name: Deploy
         id: deployment
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './build'
   deploy:
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Update all GitHub Actions in deploy workflow to latest major versions
- Drops node20 runtime dependency in favor of node22+
- checkout v4→v6, setup-node v4→v6, cache v4→v5, configure-pages v4→v6, upload-pages-artifact v3→v5, deploy-pages v4→v5

## Test plan
- [ ] Deploy workflow runs successfully on main branch after merge

Closes #55