### PR TITLE
fix: maximize workshop timetable width

### DIFF
--- a/src/routes/[lang=lang]/+layout.svelte
+++ b/src/routes/[lang=lang]/+layout.svelte
@@ -35,7 +35,7 @@
 </svelte:head>
 
 <Header {data} />
-<div class="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 sm:gap-0 p-4">
+<div class="flex min-h-screen w-full flex-col gap-6 sm:gap-0 py-4 px-8">
   {#if !isHomepage}
     <Breadcrumb {data} />
   {/if}

--- a/src/routes/[lang=lang]/program-schedule/workshops/+page.svelte
+++ b/src/routes/[lang=lang]/program-schedule/workshops/+page.svelte
@@ -29,7 +29,7 @@
   <title>{$t('nav.program_sub.workshops')} - {$t('title')}</title>
 </svelte:head>
 
-<div class="container mx-auto px-4 py-8">
+<div class="py-4">
   <h1 class="text-4xl font-bold mb-8">{$t('nav.program_sub.workshops')}</h1>
 
   <div class="prose max-w-none mb-8">


### PR DESCRIPTION
It would be nice to show timetable as large as possible

- Previous one

<img width="1937" height="1222" alt="image" src="https://github.com/user-attachments/assets/c6fe762b-5429-4830-a1cf-deca6bf7e6f0" />

- New one

<img width="1907" height="1373" alt="image" src="https://github.com/user-attachments/assets/c1517422-0666-4470-b13b-afe813d8efb0" />
