### PR TITLE
Add Academic Track presentations and split into two tables

### DIFF
--- a/data/foss4g-2026-academic-track_sessions.json
+++ b/data/foss4g-2026-academic-track_sessions.json
@@ -1,0 +1,294 @@
+[
+  {
+    "ID": "3BRTB8",
+    "Proposal title": "GIS-Based Walking Map Isochrones in Measuring Transit Catchment: A Spatial Approach to Urban Accessibility",
+    "Speaker names": [
+      "Maisarah"
+    ]
+  },
+  {
+    "ID": "8AQ7Q9",
+    "Proposal title": "Capturing park-use behavior patterns using volunteered street view imagery: Does the likelihood increase with the volume of contributions?",
+    "Speaker names": [
+      "Xinrui Zheng"
+    ]
+  },
+  {
+    "ID": "8FLCZL",
+    "Proposal title": "UrbanGraphSAGE: A Reproducible Open\u2011Source Graph Neural Network Pipeline for Building Footprint Extraction from Sentinel\u20112 in Algiers",
+    "Speaker names": [
+      "MAAMAR ARBOUZ"
+    ]
+  },
+  {
+    "ID": "8TQ9TG",
+    "Proposal title": "Spatiotemporal Analysis of OpenStreetMap Editing Activities in Japan Using the OSMCha",
+    "Speaker names": [
+      "Toshikazu Seto"
+    ]
+  },
+  {
+    "ID": "A8HJRP",
+    "Proposal title": "Machine Learning for Terrain Traversability Mapping: Accuracy, Uncertainty, and Data Limitations",
+    "Speaker names": [
+      "Marek Wyszy\u0144ski",
+      "Krzysztof Pokonieczny"
+    ]
+  },
+  {
+    "ID": "BJKCBD",
+    "Proposal title": "Analysis of the Gap Between Walkability for Older Adults and the Actual Physical Environment Using Gradient-Aware Network Analysis: A Case Study of the Area Surrounding Shin-Yurigaoka Station",
+    "Speaker names": [
+      "Hinako Terado"
+    ]
+  },
+  {
+    "ID": "C87UJX",
+    "Proposal title": "Open Disaster Response (OpenDR) 1.0: A Multidimensional Cloud-Native Framework for Real-Time GeoAI, Multi-Sensor Fusion, and Humanitarian Intelligence",
+    "Speaker names": [
+      "Bayilla Geda"
+    ]
+  },
+  {
+    "ID": "DNVPKT",
+    "Proposal title": "Between Sacred Tradition and Urban Form: An OpenStreetMap-Based Analysis of Church Orientation Patterns in Milan",
+    "Speaker names": [
+      "Taichi Furuhashi",
+      "Hinako Terado"
+    ]
+  },
+  {
+    "ID": "DXWTBW",
+    "Proposal title": "Comparative Analysis of Multi-Sensor Responses for Maize Yield Estimation",
+    "Speaker names": [
+      "Esnart Sandikonda"
+    ]
+  },
+  {
+    "ID": "EH3UUL",
+    "Proposal title": "A Systematic Comparison of RAG Architectures for Geographic POI Question Answering Using OpenStreetMap Data",
+    "Speaker names": [
+      "Noboru Otsuka"
+    ]
+  },
+  {
+    "ID": "EHMHQL",
+    "Proposal title": "Towards Automated Map JSON Style  from Spatial Vector Data Using MCP",
+    "Speaker names": [
+      "Arissara Sompita"
+    ]
+  },
+  {
+    "ID": "ESKRCL",
+    "Proposal title": "From Raw ADS-B Signals to Reproducible Flight Trajectories: An Open Geospatial Workflow for Narita Airport",
+    "Speaker names": [
+      "Junta Tagusari"
+    ]
+  },
+  {
+    "ID": "F9LRPL",
+    "Proposal title": "Tool Selection for Detailed Accessibility Analysis Using GTFS Data: The Case of the Yamagata Urban Area",
+    "Speaker names": [
+      "Shota Yamamoto"
+    ]
+  },
+  {
+    "ID": "FQU8JR",
+    "Proposal title": "Open-Source Spatiotemporal Traffic Congestion Analysis at City Scale: A Reproducible Python Pipeline Combining PySAL, OSMnx, and Multilevel Modeling",
+    "Speaker names": [
+      "Firman Hadi",
+      "Fauzan Abdullah"
+    ]
+  },
+  {
+    "ID": "FZSEMG",
+    "Proposal title": "Global contributors, local maps: the story of OpenStreetMap in a small town",
+    "Speaker names": [
+      "Sterling Quinn"
+    ]
+  },
+  {
+    "ID": "GHZ7HE",
+    "Proposal title": "A Comprehensive Disaster Risk Analysis Model with GeoAI",
+    "Speaker names": [
+      "Muhammed Oguzhan Mete"
+    ]
+  },
+  {
+    "ID": "GUYLJD",
+    "Proposal title": "Towards a Spatial Knowledge Mesh: A Metamodel for Federated and Interoperable Spatial Knowledge Graphs to Enable Geospatial Awareness, Integrity, Provenance, and Trust in Large Language Models",
+    "Speaker names": [
+      "Nathan McEachen"
+    ]
+  },
+  {
+    "ID": "HALY9B",
+    "Proposal title": "From Ancient Legends to Pixels: Reconstructing Ancient Esna Landscape with GIS and Remote Sensing",
+    "Speaker names": [
+      "TonyLiu"
+    ]
+  },
+  {
+    "ID": "JMCYAC",
+    "Proposal title": "Development of open-source environment Digital Twin framework",
+    "Speaker names": [
+      "Matthew Wilson",
+      "Luke Parkinson"
+    ]
+  },
+  {
+    "ID": "JWLHGA",
+    "Proposal title": "Geospatial Intelligence for Forest Fire Management: A FOSS4G Perspective",
+    "Speaker names": [
+      "Him Lal Shrestha",
+      "Rabina Shrestha"
+    ]
+  },
+  {
+    "ID": "KUNXTC",
+    "Proposal title": "Open-Source QGIS-Based Analysis of Coastal LULC Change and Drivers in the Niger Delta (1986\u20132026) with 2050 Scenario Projections",
+    "Speaker names": [
+      "Dr.Victor N.Sunday",
+      "Grace Martins-Ateli"
+    ]
+  },
+  {
+    "ID": "NJLL3K",
+    "Proposal title": "Comparative analysis of route and health care facilities for the emergency patients of Pune and Bengaluru",
+    "Speaker names": [
+      "Adwait Priyadarshan"
+    ]
+  },
+  {
+    "ID": "PYU8TZ",
+    "Proposal title": "Open-Source Geospatial Workflow for Hydro-Morphological Vulnerability Modelling in Deltaic Systems Using FOSS4G: Application to the Core Niger Delta, Nigeria",
+    "Speaker names": [
+      "Dr.Victor N.Sunday"
+    ]
+  },
+  {
+    "ID": "QBD7LX",
+    "Proposal title": "An open-source GeoAI workflow for mapping historic agricultural terraces",
+    "Speaker names": [
+      "Filippo Brandolini"
+    ]
+  },
+  {
+    "ID": "QCPKXQ",
+    "Proposal title": "Using WRF-UCM as Boundary Forcing for Microscale Models in Data-Scarce Urban Environments",
+    "Speaker names": [
+      "Tom\u00e1\u0161 Fedor",
+      "Jaroslav Hofierka"
+    ]
+  },
+  {
+    "ID": "QLKER8",
+    "Proposal title": "Comparing uncertainty quantification methods for Random Forest-based digital soil mapping",
+    "Speaker names": [
+      "Liina Hints"
+    ]
+  },
+  {
+    "ID": "QZLDZG",
+    "Proposal title": "Rectangular vs Hexagonal Grid Tessellation for Spatial Analysis of Invasive Species: A Case Study of Aromia bungii in Saitama, Japan.",
+    "Speaker names": [
+      "Narumasa Tsutsumida",
+      "Irhamillah"
+    ]
+  },
+  {
+    "ID": "SBUA8B",
+    "Proposal title": "Mapping Nearshore Cladophora in Lake Ontario: An Automated Open-Source Sentinel-2 Workflow and Experimental Index Derivation",
+    "Speaker names": [
+      "TonyLiu"
+    ]
+  },
+  {
+    "ID": "SNBLLQ",
+    "Proposal title": "Application of SUMO in Simulation of Optimized Traffic Light Timing derived using Artificial Neural Network and GIS",
+    "Speaker names": [
+      "Nabilah Naharudin"
+    ]
+  },
+  {
+    "ID": "TMX8HE",
+    "Proposal title": "Geographic Visualization of the Kaii-Yokai Folklore Database Using Open-Source GIS and NLP",
+    "Speaker names": [
+      "Kosuke Shimizu"
+    ]
+  },
+  {
+    "ID": "UUYLME",
+    "Proposal title": "Integrating Machine Learning with Open-Source GIS for Reproducible High-Resolution Terrain Classification and Hazard Mapping from UAV LiDAR Data",
+    "Speaker names": [
+      "Nikola Kranj\u010di\u0107"
+    ]
+  },
+  {
+    "ID": "UXU7LH",
+    "Proposal title": "A Pipeline for Low-Cost Wide-Area 3D Mapping Using LiDAR-Equipped Mobile Devices and Open Data",
+    "Speaker names": [
+      "Ryosei Ueda"
+    ]
+  },
+  {
+    "ID": "VYWSCK",
+    "Proposal title": "DINO-EdgeQuery: Edge-First Polygon Decoding for Building Footprint Extraction from Satellite imagery",
+    "Speaker names": [
+      "Yuji Kobayashi"
+    ]
+  },
+  {
+    "ID": "WUMCKV",
+    "Proposal title": "Shared Landscapes, Shared Futures: Visual Landscape Evolution Modelling for Community Stewardship",
+    "Speaker names": [
+      "Vinuri Piyathilake"
+    ]
+  },
+  {
+    "ID": "XBZYE7",
+    "Proposal title": "Learning with Spaceborne LiDAR for Enhancement of Bare-Earth Digital Elevation Models from Global Data",
+    "Speaker names": [
+      "Xiandong Cai"
+    ]
+  },
+  {
+    "ID": "XVK8JN",
+    "Proposal title": "MUSUBOU-AR: An Open-Source Geospatial AR Framework for Integrating Public GIS Data, Field Authoring, and Disaster Walking Tours",
+    "Speaker names": [
+      "Daisuke Yoshida"
+    ]
+  },
+  {
+    "ID": "YDWGPA",
+    "Proposal title": "Aitchison-Loss Training with Geospatial Embeddings Sharpens Compositional Land-Cover Maps",
+    "Speaker names": [
+      "Narumasa Tsutsumida",
+      "Ayato Kanno"
+    ]
+  },
+  {
+    "ID": "YEEKAW",
+    "Proposal title": "Examining the Relationship Between Tatara Iron Production and Grassland Distribution in Western Japan: An Open Geospatial Approach to Historical Landscape Analysis",
+    "Speaker names": [
+      "Nobusuke Iwasaki",
+      "Ayaka Onohara",
+      "Takatora Bito"
+    ]
+  },
+  {
+    "ID": "YMWRET",
+    "Proposal title": "Extending GeoNode as a Foundation for Research Data Management Infrastructures in Agricultural Research",
+    "Speaker names": [
+      "Marcel Wallschl\u00e4ger",
+      "Igo Silva de Almeida"
+    ]
+  },
+  {
+    "ID": "YPKLE7",
+    "Proposal title": "Linking provider catchment and SaTScan risk clusters for evidence-based public health nursing in Japan",
+    "Speaker names": [
+      "Ryo Horiike"
+    ]
+  }
+]

--- a/data/foss4g-2026_sessions.json
+++ b/data/foss4g-2026_sessions.json
@@ -1,5 +1,12 @@
 [
   {
+    "ID": "33TQQC",
+    "Proposal title": "Bringing Old Maps & Illustrated Maps to the Web: 10 Years of Maplat and Turning Misalignment into Innovation",
+    "Speaker names": [
+      "KOHEI OTSUKA"
+    ]
+  },
+  {
     "ID": "37T8AK",
     "Proposal title": "The #1 plugin for QGIS",
     "Speaker names": [
@@ -25,6 +32,13 @@
     "Proposal title": "Apache SIS for integrated metadata, referencing and grid coverage services",
     "Speaker names": [
       "Martin Desruisseaux"
+    ]
+  },
+  {
+    "ID": "3DHJXR",
+    "Proposal title": "Mapping Peace: A GIS-Based Storytelling Platform for Global Peace Education from Hiroshima",
+    "Speaker names": [
+      "Hiroshima Funairi High School"
     ]
   },
   {
@@ -89,7 +103,14 @@
     "ID": "778RKA",
     "Proposal title": "Current GIS Applications in Hokkaido Agriculture and Hokuren's FOSS4G Initiatives with QGIS",
     "Speaker names": [
-      "\u5c71\u672c\u96c4\u98db"
+      "Yuhi Yamamoto"
+    ]
+  },
+  {
+    "ID": "77WDWM",
+    "Proposal title": "Mapping invasive canopy-smothering vines in the tropical Pacific using SAR and open-source geospatial tools",
+    "Speaker names": [
+      "Iosefa Percival"
     ]
   },
   {
@@ -129,6 +150,13 @@
     ]
   },
   {
+    "ID": "7RGJVD",
+    "Proposal title": "FBIS Africa: Freshwater biodiversity data from Africa, for Africa.",
+    "Speaker names": [
+      "Dimas Tri Ciputra"
+    ]
+  },
+  {
     "ID": "7TW8PW",
     "Proposal title": "Open Disaster Response (OpenDR) 1.0: Real-Time Cloud-Native GeoAI and Multi-Sensor Fusion for Humanitarian Intelligence",
     "Speaker names": [
@@ -153,7 +181,7 @@
     "ID": "7WWFAY",
     "Proposal title": "Utilizing detailed geographic information open data",
     "Speaker names": [
-      "mori@mikuniya.co.jp"
+      "Yoshimasa Mori, Shota Sato,Akana Matsuda"
     ]
   },
   {
@@ -218,7 +246,7 @@
     "ID": "8JWRBE",
     "Proposal title": "Reproducibility in geospatial research: a case study.",
     "Speaker names": [
-      "Rosa Aguilar, Pitchaporn Likitpanjamanon, Frank Ostermann"
+      "Rosa Aguilar"
     ]
   },
   {
@@ -297,7 +325,8 @@
     "Proposal title": "pygeoapi project status",
     "Speaker names": [
       "Tom Kralidis",
-      "Angelos Tzotsos"
+      "Angelos Tzotsos",
+      "Joana Simoes"
     ]
   },
   {
@@ -363,6 +392,7 @@
     "ID": "9FN7PW",
     "Proposal title": "Standardizing Geospatial Time Series Access with OGC API EDR and RDF Linked Data Standards",
     "Speaker names": [
+      "Benjamin Webb",
       "Colton Loftus"
     ]
   },
@@ -530,6 +560,13 @@
     "Proposal title": "ESGF Next Generation",
     "Speaker names": [
       "Rhys Evans"
+    ]
+  },
+  {
+    "ID": "BJFRLD",
+    "Proposal title": "Applying OSS \u201cOuranos GEX\u201d: Lessons from PoC and the Path to Java-Based Development",
+    "Speaker names": [
+      "Nan Si"
     ]
   },
   {
@@ -846,6 +883,13 @@
     ]
   },
   {
+    "ID": "ERGRGW",
+    "Proposal title": "50 Lines of Python: Neighborhood DNA from Overture Maps Places",
+    "Speaker names": [
+      "Marija Ercegovac"
+    ]
+  },
+  {
     "ID": "ESK9ZX",
     "Proposal title": "GeoNode usage in Brazil: State of art, challenges, and business opportunities",
     "Speaker names": [
@@ -904,10 +948,17 @@
     ]
   },
   {
+    "ID": "FMPNE3",
+    "Proposal title": "asahina proposal test",
+    "Speaker names": [
+      "Hinako Iseki"
+    ]
+  },
+  {
     "ID": "FQ3BSJ",
     "Proposal title": "Lack of Open-Source Border Datasets on Sensitive Border Areas: The Case of the China\u2013Bhutan Border and Arunachal Pradesh",
     "Speaker names": [
-      "\u9152\u4e95\u8087"
+      "Jo Sakai"
     ]
   },
   {
@@ -915,6 +966,13 @@
     "Proposal title": "Methods for Introducing Geospatial Awareness to Large Language Models with Integrity, Provenance, and Trust through Open Standards and Open Source",
     "Speaker names": [
       "Nathan McEachen"
+    ]
+  },
+  {
+    "ID": "FRJANH",
+    "Proposal title": "GeoAgent: A QGIS Plugin for Natural Language-Driven Geospatial Analysis",
+    "Speaker names": [
+      "Tek Bahadur Kshetri"
     ]
   },
   {
@@ -1070,7 +1128,8 @@
     "ID": "GZPBN3",
     "Proposal title": "Making drainage engineers' life easy: A culvert designers plug-in for QGIS",
     "Speaker names": [
-      "Blake"
+      "Blake",
+      "Nimalika Fernando"
     ]
   },
   {
@@ -1193,7 +1252,8 @@
     "Speaker names": [
       "Carlos Eduardo Mota",
       "Mauricio Marino",
-      "Matheus Klein Flach"
+      "Matheus Klein Flach",
+      "Tiago Antonelli"
     ]
   },
   {
@@ -1445,7 +1505,7 @@
     "Proposal title": "Accuracy Verification of Three-Dimensional Models Around the Tottori Sand Dunes Created from Historical Aerial Photographs",
     "Speaker names": [
       "Nobusuke Iwasaki",
-      "Shota"
+      "Shota Toso"
     ]
   },
   {
@@ -1484,13 +1544,6 @@
     "Proposal title": "Making Maps Readable: A Dive into Font Rendering in Navara",
     "Speaker names": [
       "Adel Refaat"
-    ]
-  },
-  {
-    "ID": "N37VVC",
-    "Proposal title": "Building spatial databases with MakeGIS",
-    "Speaker names": [
-      "Christophe Thiange"
     ]
   },
   {
@@ -1533,13 +1586,6 @@
     "Proposal title": "Mapping Peace: A GIS-Based Storytelling Platform for Global Peace Education from Hiroshima",
     "Speaker names": [
       "Hiroshima Funairi High School"
-    ]
-  },
-  {
-    "ID": "NVAAA8",
-    "Proposal title": "Geoprivacy in the Field: Integrating Privacy-Preserving Spatial Transformations into the QField Mobile GIS Platform",
-    "Speaker names": [
-      "Dr Pankajeshwara Sharma"
     ]
   },
   {
@@ -1742,6 +1788,7 @@
     "ID": "R7GEQB",
     "Proposal title": "Running pygeoapi Cloud Native at Scale",
     "Speaker names": [
+      "Benjamin Webb",
       "Colton Loftus"
     ]
   },
@@ -1765,6 +1812,13 @@
     "Speaker names": [
       "Alex Leith",
       "William Jones"
+    ]
+  },
+  {
+    "ID": "RBBMRZ",
+    "Proposal title": "From Binary to Web Maps: Teaching GIS Programming in the Kartoza Internship",
+    "Speaker names": [
+      "Zulfikar Akbar Muzakki"
     ]
   },
   {
@@ -1869,6 +1923,13 @@
     ]
   },
   {
+    "ID": "SA7BNH",
+    "Proposal title": "Turning Statistics into Maps with UNICEF\u2019s Open Source Geospatial Solutions",
+    "Speaker names": [
+      "Jan Burdziej"
+    ]
+  },
+  {
     "ID": "SBUMDY",
     "Proposal title": "Using Lonboard for interactive STAC, COG, and Zarr visualization from Python",
     "Speaker names": [
@@ -1903,7 +1964,9 @@
     "ID": "SYBPRD",
     "Proposal title": "Voxelization. Cubing 3D Space for Machine.",
     "Speaker names": [
-      "Hak joon Kim"
+      "Hak joon Kim",
+      "Seungmin Kwon",
+      "joohyoung Kim"
     ]
   },
   {
@@ -1917,8 +1980,6 @@
     "ID": "SZ83SS",
     "Proposal title": "Mapping Fiber Without Operator Data: Evidence-Based Connectivity Indicators",
     "Speaker names": [
-      "Philipp Kleer",
-      "Carolina de Almeida Caetano",
       "CRISTIANE HONORA MILLAN"
     ]
   },
@@ -1927,6 +1988,13 @@
     "Proposal title": "Beyond Shapefile: A Taxonomy of Modern Geospatial Data Formats",
     "Speaker names": [
       "Markus Tremmel"
+    ]
+  },
+  {
+    "ID": "T3DTHT",
+    "Proposal title": "Eurostat vs OSM vs Census: Choosing Open Mobility Data for Urban Function Maps",
+    "Speaker names": [
+      "Marija Ercegovac"
     ]
   },
   {
@@ -1941,7 +2009,7 @@
     "Proposal title": "Detecting Rooftop Solar Panels with Deep Learning, using Open Remote Sensing Data and OpenStreetMap",
     "Speaker names": [
       "Danielle",
-      "Gefei"
+      "Gefei Kong"
     ]
   },
   {
@@ -2026,7 +2094,9 @@
     "ID": "TSHBPR",
     "Proposal title": "End-to-End Deep Learning Analysis Pipeline for Early-Season Crop Mapping using Sentinel Data and Continuous Wavelet Transforms",
     "Speaker names": [
-      "Thantham Khamyai"
+      "Sarawut Ninsawat",
+      "Thantham Khamyai",
+      "sittichai choosumrong"
     ]
   },
   {
@@ -2186,13 +2256,6 @@
     ]
   },
   {
-    "ID": "VW8FXJ",
-    "Proposal title": "Rise of the Machines, Rise of the Workers",
-    "Speaker names": [
-      "Jonah Sullivan"
-    ]
-  },
-  {
     "ID": "WD3DHU",
     "Proposal title": "End-to-End Satellite Data Pipeline: Airflow Orchestration, Zarr Storage, and LandTrendr Analysis",
     "Speaker names": [
@@ -2225,6 +2288,13 @@
     "Proposal title": "Bridging the Geospatial Data Gap in Africa with QGIS and OpenStreetMap",
     "Speaker names": [
       "Ruvimbo  Doreen Supiya"
+    ]
+  },
+  {
+    "ID": "WPCPST",
+    "Proposal title": "Establishing an Automated 3D Geospatial Data Pipeline for a National Digital Land Platform",
+    "Speaker names": [
+      "JIYOON KWON"
     ]
   },
   {
@@ -2379,6 +2449,7 @@
     "ID": "ZKUQYS",
     "Proposal title": "Geoconnex: Standardizing Water Data in the United States through a Unified Graph Database",
     "Speaker names": [
+      "Benjamin Webb",
       "Colton Loftus"
     ]
   },

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -291,8 +291,10 @@
   "presentations": {
     "announcement": "Program details will be announced in April 2026",
     "title": "Presentations",
-    "confirmed_note": "Only presentations that have been confirmed in the proposal submission system are displayed below. This data is as of April 22, 2026.",
+    "confirmed_note": "Only presentations that have been confirmed in the proposal submission system are displayed below. This data is as of May 19, 2026.",
     "search_placeholder": "Search by title or speaker name...",
+    "general_tracks": "General Tracks",
+    "academic_tracks": "Academic Tracks",
     "table_id": "ID",
     "table_title": "Title",
     "table_speakers": "Speakers",

--- a/src/lib/translations/ja.json
+++ b/src/lib/translations/ja.json
@@ -291,8 +291,10 @@
   "presentations": {
     "announcement": "プログラムの詳細は2026年4月に公開予定です",
     "title": "発表",
-    "confirmed_note": "以下は、提案投稿システムで確認済みの発表のみ表示しています。このデータは2026年4月22日時点のものです。",
+    "confirmed_note": "以下は、提案投稿システムで確認済みの発表のみ表示しています。このデータは2026年5月19日時点のものです。",
     "search_placeholder": "タイトルまたは発表者名で検索...",
+    "general_tracks": "General Tracks",
+    "academic_tracks": "Academic Tracks",
     "table_id": "ID",
     "table_title": "タイトル",
     "table_speakers": "発表者",

--- a/src/routes/[lang=lang]/program-schedule/presentations/+page.svelte
+++ b/src/routes/[lang=lang]/program-schedule/presentations/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { t } from 'svelte-i18n'
-  import sessions from '../../../../../data/foss4g-2026_sessions.json'
+  import generalSessions from '../../../../../data/foss4g-2026_sessions.json'
+  import academicSessions from '../../../../../data/foss4g-2026-academic-track_sessions.json'
 
   interface Session {
     ID: string
@@ -8,20 +9,26 @@
     'Speaker names': string[]
   }
 
-  const allSessions: Session[] = (sessions as Session[]).sort((a, b) =>
+  const sortBySpeaker = (a: Session, b: Session) =>
     a['Speaker names'][0].localeCompare(b['Speaker names'][0])
-  )
+
+  const allGeneral: Session[] = (generalSessions as Session[]).slice().sort(sortBySpeaker)
+  const allAcademic: Session[] = (academicSessions as Session[]).slice().sort(sortBySpeaker)
 
   let searchQuery = $state('')
 
-  const filteredSessions = $derived(() => {
-    if (!searchQuery.trim()) return allSessions
-    const query = searchQuery.toLowerCase()
-    return allSessions.filter(
-      (s) =>
-        s['Proposal title'].toLowerCase().includes(query) ||
-        s['Speaker names'].some((name) => name.toLowerCase().includes(query))
-    )
+  const matchesQuery = (s: Session, query: string) =>
+    s['Proposal title'].toLowerCase().includes(query) ||
+    s['Speaker names'].some((name) => name.toLowerCase().includes(query))
+
+  const filteredGeneral = $derived(() => {
+    const q = searchQuery.trim().toLowerCase()
+    return q ? allGeneral.filter((s) => matchesQuery(s, q)) : allGeneral
+  })
+
+  const filteredAcademic = $derived(() => {
+    const q = searchQuery.trim().toLowerCase()
+    return q ? allAcademic.filter((s) => matchesQuery(s, q)) : allAcademic
   })
 </script>
 
@@ -36,40 +43,78 @@
     <p class="text-yellow-800">{$t('presentations.confirmed_note')}</p>
   </div>
 
-  <div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+  <div class="mb-8">
     <input
       type="text"
       bind:value={searchQuery}
       placeholder={$t('presentations.search_placeholder')}
       class="input input-bordered w-full sm:max-w-md"
     />
-    <span class="text-sm text-gray-500">
-      {filteredSessions().length} {$t('presentations.total_count')}
-    </span>
   </div>
 
-  <div class="overflow-x-auto">
-    <table class="table table-zebra w-full">
-      <thead>
-        <tr>
-          <th>{$t('presentations.table_title')}</th>
-          <th class="w-64">{$t('presentations.table_speakers')}</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each filteredSessions() as session (session.ID)}
+  <section class="mb-12">
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
+      <h2 class="text-2xl font-semibold">{$t('presentations.general_tracks')}</h2>
+      <span class="text-sm text-gray-500">
+        {filteredGeneral().length} {$t('presentations.total_count')}
+      </span>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="table table-zebra w-full">
+        <thead>
           <tr>
-            <td>{session['Proposal title']}</td>
-            <td>{session['Speaker names'].join(', ')}</td>
+            <th>{$t('presentations.table_title')}</th>
+            <th class="w-64">{$t('presentations.table_speakers')}</th>
           </tr>
-        {:else}
+        </thead>
+        <tbody>
+          {#each filteredGeneral() as session (session.ID)}
+            <tr>
+              <td>{session['Proposal title']}</td>
+              <td>{session['Speaker names'].join(', ')}</td>
+            </tr>
+          {:else}
+            <tr>
+              <td colspan="2" class="text-center text-gray-500 py-8">
+                {$t('presentations.no_results')}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-4">
+      <h2 class="text-2xl font-semibold">{$t('presentations.academic_tracks')}</h2>
+      <span class="text-sm text-gray-500">
+        {filteredAcademic().length} {$t('presentations.total_count')}
+      </span>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="table table-zebra w-full">
+        <thead>
           <tr>
-            <td colspan="2" class="text-center text-gray-500 py-8">
-              {$t('presentations.no_results')}
-            </td>
+            <th>{$t('presentations.table_title')}</th>
+            <th class="w-64">{$t('presentations.table_speakers')}</th>
           </tr>
-        {/each}
-      </tbody>
-    </table>
-  </div>
+        </thead>
+        <tbody>
+          {#each filteredAcademic() as session (session.ID)}
+            <tr>
+              <td>{session['Proposal title']}</td>
+              <td>{session['Speaker names'].join(', ')}</td>
+            </tr>
+          {:else}
+            <tr>
+              <td colspan="2" class="text-center text-gray-500 py-8">
+                {$t('presentations.no_results')}
+              </td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  </section>
 </div>


### PR DESCRIPTION
## Summary
- Add academic track sessions JSON (40 sessions)
- Update general sessions JSON to latest snapshot (343 sessions)
- Display General Tracks and Academic Tracks in separate tables on the Presentations page
- Search box filters both tables simultaneously
- Update data date to May 19, 2026

## Test plan
- [ ] Presentations page shows two tables: General Tracks and Academic Tracks
- [ ] Each table has its own session count next to the heading
- [ ] Search box filters both tables at the same time
- [ ] Date note shows "May 19, 2026" (en) and "2026年5月19日" (ja)