### PR TITLE
Update homepage news for VISA fee increase

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -39,6 +39,12 @@
           "description": "View details",
           "link": "/program-schedule/poster-session"
         },
+        "visa_fee_increase": {
+          "date": "June 27, 2026",
+          "title": "VISA fees will increase from July 1",
+          "description": "Details here",
+          "link": "https://www.mofa.go.jp/j_info/visit/visa/procedure/pagewe_000001_00391.html"
+        },
         "website_update": {
           "date": "June 10, 2026",
           "title": "New Sponsor Logos Added",

--- a/src/lib/translations/ja.json
+++ b/src/lib/translations/ja.json
@@ -137,6 +137,12 @@
           "description": "詳細を見る",
           "link": "/program-schedule/poster-session"
         },
+        "visa_fee_increase": {
+          "date": "2026年6月27日",
+          "title": "7月1日からVISAの費用が値上げされます",
+          "description": "詳細はこちら",
+          "link": "https://www.mofa.go.jp/j_info/visit/visa/procedure/pagewe_000001_00391.html"
+        },
         "website_update": {
           "date": "2026年6月10日",
           "title": "新規スポンサーロゴを掲載しました",

--- a/src/routes/[lang=lang]/+page.svelte
+++ b/src/routes/[lang=lang]/+page.svelte
@@ -82,6 +82,18 @@
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
           <!-- News Item 1 -->
           <div class="space-y-2">
+            <p class="text-xs text-gray-600">{$t('teaser.news.items.visa_fee_increase.date')}</p>
+            <h3 class="text-lg font-normal text-gray-900">
+              {$t('teaser.news.items.visa_fee_increase.title')}
+            </h3>
+            <p class="text-sm text-gray-600">
+              <a href="{$t('teaser.news.items.visa_fee_increase.link')}" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">
+                {$t('teaser.news.items.visa_fee_increase.description')}
+              </a>
+            </p>
+          </div>
+          <!-- News Item 2 -->
+          <div class="space-y-2">
             <p class="text-xs text-gray-600">{$t('teaser.news.items.community_events_map.date')}</p>
             <h3 class="text-lg font-normal text-gray-900">
               {$t('teaser.news.items.community_events_map.title')}
@@ -92,7 +104,7 @@
               </a>
             </p>
           </div>
-          <!-- News Item 2 -->
+          <!-- News Item 3 -->
           <div class="space-y-2">
             <p class="text-xs text-gray-600">{$t('teaser.news.items.pss_sponsor.date')}</p>
             <h3 class="text-lg font-normal text-gray-900">
@@ -100,18 +112,6 @@
             </h3>
             <p class="text-sm text-gray-600">
               {$t('teaser.news.items.pss_sponsor.description')}
-            </p>
-          </div>
-          <!-- News Item 3 -->
-          <div class="space-y-2">
-            <p class="text-xs text-gray-600">{$t('teaser.news.items.poster_session_launch.date')}</p>
-            <h3 class="text-lg font-normal text-gray-900">
-              {$t('teaser.news.items.poster_session_launch.title')}
-            </h3>
-            <p class="text-sm text-gray-600">
-              <a href="/{$t('nav.languages.current_language') === 'English' ? 'en' : 'ja'}{$t('teaser.news.items.poster_session_launch.link')}" class="text-blue-600 hover:underline">
-                {$t('teaser.news.items.poster_session_launch.description')}
-              </a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add VISA fee increase NEWS translations in Japanese and English
- Show the VISA fee increase notice as the leftmost/latest homepage NEWS item
- Keep the poster session NEWS content in translation data without displaying it in the top 3

## Verification
- npm run build